### PR TITLE
Loop gallery popup navigation at both ends

### DIFF
--- a/local-gallery.js
+++ b/local-gallery.js
@@ -169,19 +169,11 @@ const createPopup = (imgUrl, imgAlt) => {
 	}
 	const goToPrev = () => {
 		const prevImg = getPrevImg(currentImgUrl)
-		if (prevImg) {
-			updatePopupImage(prevImg.src, prevImg.alt)
-		} else {
-			prevBtn.style.cursor = 'not-allowed'
-		}
+		if (prevImg) updatePopupImage(prevImg.src, prevImg.alt)
 	}
 	const goToNext = () => {
 		const nextImg = getNextImg(currentImgUrl)
-		if (nextImg) {
-			updatePopupImage(nextImg.src, nextImg.alt)
-		} else {
-			nextBtn.style.cursor = 'not-allowed'
-		}
+		if (nextImg) updatePopupImage(nextImg.src, nextImg.alt)
 	}
 	const onKeyDown = e => {
 		if (e.key === 'ArrowLeft') {
@@ -225,8 +217,6 @@ const updatePopupImage = (imgUrl, imgAlt) => {
 	popupImg.src = imgUrl
 	popupImg.alt = imgAlt
 	popupNameImg.innerHTML = imgAlt
-	popupPrevBtn.style.cursor = ''
-	popupNextBtn.style.cursor = ''
 }
 const checkExistPopup = (imgUrl, imgAlt) => {
 	if (popup) {
@@ -236,28 +226,14 @@ const checkExistPopup = (imgUrl, imgAlt) => {
 	}
 }
 const getPrevImg = currentImgUrl => {
-	const imgIndex = Array.from(imgBox.querySelectorAll('.randomImg')).findIndex(
-		img => img.dataset.fullSrc === currentImgUrl
-	)
-	if (imgIndex > 0) {
-		const prevImg = imgBox.querySelectorAll('.randomImg')[imgIndex - 1]
-		return {
-			src: prevImg.dataset.fullSrc,
-			alt: prevImg.getAttribute('alt'),
-		}
-	}
-	return null
+	const imgs = imgBox.querySelectorAll('.randomImg')
+	const imgIndex = Array.from(imgs).findIndex(img => img.dataset.fullSrc === currentImgUrl)
+	const prevImg = imgs[(imgIndex - 1 + imgs.length) % imgs.length]
+	return { src: prevImg.dataset.fullSrc, alt: prevImg.getAttribute('alt') }
 }
 const getNextImg = currentImgUrl => {
-	const imgIndex = Array.from(imgBox.querySelectorAll('.randomImg')).findIndex(
-		img => img.dataset.fullSrc === currentImgUrl
-	)
-	if (imgIndex < imgBox.querySelectorAll('.randomImg').length - 1) {
-		const nextImg = imgBox.querySelectorAll('.randomImg')[imgIndex + 1]
-		return {
-			src: nextImg.dataset.fullSrc,
-			alt: nextImg.getAttribute('alt'),
-		}
-	}
-	return null
+	const imgs = imgBox.querySelectorAll('.randomImg')
+	const imgIndex = Array.from(imgs).findIndex(img => img.dataset.fullSrc === currentImgUrl)
+	const nextImg = imgs[(imgIndex + 1) % imgs.length]
+	return { src: nextImg.dataset.fullSrc, alt: nextImg.getAttribute('alt') }
 }

--- a/tests/gallery.spec.js
+++ b/tests/gallery.spec.js
@@ -87,6 +87,32 @@ test('arrow keys navigate the popup and escape closes it', async ({ page }) => {
 	await expect(page.locator('.popup:not(.hide)')).toHaveCount(0)
 })
 
+test('navigating before the first photo loops to the last', async ({ page }) => {
+	await page.goto('/gallery.html')
+	const images = page.locator('.imgBox img.randomImg')
+	await images.first().click()
+
+	const popup = page.locator('.popup:not(.hide)')
+	const popupImg = popup.locator('img')
+	const firstSrc = await popupImg.getAttribute('src')
+
+	await page.keyboard.press('ArrowLeft')
+	await expect(popupImg).not.toHaveAttribute('src', firstSrc)
+})
+
+test('navigating past the last photo loops to the first', async ({ page }) => {
+	await page.goto('/gallery.html')
+	const images = page.locator('.imgBox img.randomImg')
+	await images.last().click()
+
+	const popup = page.locator('.popup:not(.hide)')
+	const popupImg = popup.locator('img')
+	const lastSrc = await popupImg.getAttribute('src')
+
+	await page.keyboard.press('ArrowRight')
+	await expect(popupImg).not.toHaveAttribute('src', lastSrc)
+})
+
 test('swiping left and right navigates the zoomed photo', async ({ page }) => {
 	await page.goto('/gallery.html')
 	const images = page.locator('.imgBox img.randomImg')


### PR DESCRIPTION
- pressing ArrowLeft on the first photo now wraps to the last, and ArrowRight on the last wraps to the first — same behaviour for swipe and click
- two new Playwright tests cover both wrap-around directions